### PR TITLE
Update some references to the forked repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ You'll first need to install [ESLint](https://eslint.org/):
 npm i eslint --save-dev
 ```
 
-Next, install `eslint-plugin-jsx-expressions`:
+Next, install `@jgoz/eslint-plugin-jsx-expressions`:
 
 ```sh
-npm install eslint-plugin-jsx-expressions --save-dev
+npm install @jgoz/eslint-plugin-jsx-expressions --save-dev
 ```
 
 ## Usage
 
-Add `jsx-expressions` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+Add `@jgoz/jsx-expressions` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
 
 ```json
 {
-  "plugins": ["jsx-expressions"]
+  "plugins": ["@jgoz/jsx-expressions"]
 }
 ```
 
@@ -31,11 +31,11 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "jsx-expressions/strict-logical-expressions": "error"
+    "@jgoz/jsx-expressions/strict-logical-expressions": "error"
   }
 }
 ```
 
 ## Supported Rules
 
-- [jsx-expressions/strict-logical-expressions](https://github.com/hluisson/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md): Enforces logical "&&" expressions do not use potentially falsey numbers or strings.
+- [jsx-expressions/strict-logical-expressions](https://github.com/jgoz/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md): Enforces logical "&&" expressions do not use potentially falsey numbers or strings.

--- a/lib/util/createRule.ts
+++ b/lib/util/createRule.ts
@@ -6,5 +6,5 @@ const version: string = require("../../package.json").version;
 
 export const createRule = ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/hluisson/eslint-plugin-jsx-expressions/blob/v${version}/lib/rules/${name}.md`
+    `https://github.com/jgoz/eslint-plugin-jsx-expressions/blob/v${version}/lib/rules/${name}.md`
 );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hluisson/eslint-plugin-jsx-expressions.git"
+    "url": "https://github.com/jgoz/eslint-plugin-jsx-expressions.git"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",


### PR DESCRIPTION
I found this fork today while looking to upgrade my eslint setup, and finding the still not merged updates to support eslint and use the latest major version of typescript-eslint on the
eslint-plugin-jsx-expressions repo.

Great that you've published an updated fork to npm! I just made some updates here so that the readme in this repo refers to the correct install instructions for the fork, and that the npm listing refers back to this GitHub repo.